### PR TITLE
Handle promises that are functions and extend to all thenables

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -32,6 +32,17 @@ test("async", async () => {
   expect(resp2).toBeUndefined();
 });
 
+test("thenable", async () => {
+  // @ts-ignore
+  const [err1, resp1] = await flatry({ then: cb => { cb(1); } });
+  const [err2, resp2] = await flatry({ then: () => { throw new Error("Oops..."); } });
+
+  expect(err1).toBeNull();
+  expect(err2).toBeDefined();
+  expect(resp1).toBe(1);
+  expect(resp2).toBeUndefined();
+});
+
 test("should throw exception if arg not a function", () => {
   // @ts-ignore
   expect(() => flatry(undefined)).toThrow();

--- a/index.ts
+++ b/index.ts
@@ -10,10 +10,9 @@ function flatryFunction<Result>(fn: FlatryFn<Result>) {
 async function flatryPromise<Error, Result>(promise: PromiseLike<Result>) {
   try {
     const value = await promise;
-    return [null, value];
+    return [null, value] as const;
   } catch (err) {
-    console.log('caught error')
-    return [err];
+    return [err] as const;
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -7,27 +7,27 @@ function flatryFunction<Result>(fn: FlatryFn<Result>) {
   }
 }
 
-function flatryPromise<Error, Result>(promise: Promise<Result>) {
-  var successFn = function (value: Result) {
-    return [null, value] as const;
-  };
-  var errorFn = function (err: Error) {
-    return [err] as const;
-  };
-  return promise.then(successFn, errorFn);
+async function flatryPromise<Error, Result>(promise: PromiseLike<Result>) {
+  try {
+    const value = await promise;
+    return [null, value];
+  } catch (err) {
+    console.log('caught error')
+    return [err];
+  }
 }
 
 export default function flatry<T>(
-  promise: Promise<T>
+  promise: PromiseLike<T>
 ): Promise<[unknown, never] | [null, T]>;
 export default function flatry<T>(fn: () => T): [unknown, never] | [null, T];
 export default function flatry(functionOrPromise: any): any {
+  if (typeof functionOrPromise.then === "function") {
+    return flatryPromise(functionOrPromise);
+  }
+  
   if (typeof functionOrPromise === "function") {
     return flatryFunction(functionOrPromise);
-  }
-
-  if (Promise.resolve(functionOrPromise) === functionOrPromise) {
-    return flatryPromise(functionOrPromise);
   }
 
   throw new Error("Argument must be a function or Promise");


### PR DESCRIPTION
In JavaScript any object that has `.then()` method ("thenable") is considered promise-like and can be awaited, it's part of the spec. For example, you can try this in Node:
```js
Welcome to Node.js v19.3.0.
Type ".help" for more information.
> const thenable = { then: (cb) => cb('Resolves!') };
undefined
> (async () => { console.log(await thenable); })();
Promise {
  <pending>,
  [Symbol(async_id_symbol)]: 123,
  [Symbol(trigger_async_id_symbol)]: 5
}
> Resolves!
```

This PR extends the library functionality to work with any thenable.

Also, an object can be a fully functioning promise, but have a function prototype. For example, [see this library](https://github.com/not-an-aardvark/promise-chains/blob/0ea9e7e3363ae1fee2a66940c84274202fc0ab04/index.js), which is used to power this popular library - https://github.com/not-an-aardvark/snoowrap.

I switched the order of checks to account for that.
